### PR TITLE
Fix typos in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 __pycache__/
 *.egg-info/
+
+ectf-venv/
+
+car_image/
+fob_image/
+package/

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ car-id and feature-number as well as shared secrets to generate a package.
 
 #### 3d. `run.enable`
 ```shell
-python3 -m ectf_tools run.enable --name <SYSTEM_NAME> --fob-bridge <FOB_SOCKET> --package_in <PACKAGE_IN> --package_name <PACKAGE_NAME>
+python3 -m ectf_tools run.enable --name <SYSTEM_NAME> --fob-bridge <FOB_SOCKET> --package-in <PACKAGE_IN> --package-name <PACKAGE_NAME>
 ```
 
 This run step invokes the enable host tool, which reads in a previously created

--- a/README.md
+++ b/README.md
@@ -358,12 +358,6 @@ containers and volumes
 docker container prune
 docker volume prune
 ```
-
-If that isn't enough, you can clean up all containers and volumes:
-```shell
-docker container prune -a
-docker volume prune -a
-```
 NOTE: these will remove all of the cached containers, so the next builds may take a longer time
 
 These are some helpful commands to have handy when managing your docker state:

--- a/scripts/Trevor/Windows/build.bat
+++ b/scripts/Trevor/Windows/build.bat
@@ -1,0 +1,14 @@
+@echo off
+call parameters.bat
+cd /D %toolsPath%
+@echo on
+
+python3 -m ectf_tools build.env --design %designPath% --name %sysName%
+python3 -m ectf_tools build.tools --design %designPath% --name %sysName%
+python3 -m ectf_tools build.depl --design %designPath% --name %sysName% --deployment %deplName%
+
+python3 -m ectf_tools build.car_fob_pair --design %designPath% --name %sysName% --deployment %deplName% --car-out %carPath% --fob-out %fobPath% --car-name %carName% --fob-name %pairName% --car-id %carID% --pair-pin %pairPIN%
+python3 -m ectf_tools build.fob --design %designPath% --name %sysName%  --deployment %deplName% --fob-out %fobPath% --fob-name %unpairName%
+
+@echo off
+pause

--- a/scripts/Trevor/Windows/loadCar.bat
+++ b/scripts/Trevor/Windows/loadCar.bat
@@ -1,0 +1,9 @@
+@echo off
+call parameters.bat
+cd /D %toolsPath%
+@echo on
+
+python3 -m ectf_tools device.load_hw --dev-in %carPath% --dev-name %carName% --dev-serial %serialPort%
+pause
+python3 -m ectf_tools device.bridge --bridge-id %carSocket% --dev-serial %serialPort%
+pause

--- a/scripts/Trevor/Windows/loadFob.bat
+++ b/scripts/Trevor/Windows/loadFob.bat
@@ -1,0 +1,9 @@
+@echo off
+call parameters.bat
+cd /D %toolsPath%
+@echo on
+
+python3 -m ectf_tools device.load_hw --dev-in %fobPath% --dev-name %pairName% --dev-serial %serialPort%
+pause
+python3 -m ectf_tools device.bridge --bridge-id %pairSocket% --dev-serial %serialPort%
+pause

--- a/scripts/Trevor/Windows/loadUnpairedFob.bat
+++ b/scripts/Trevor/Windows/loadUnpairedFob.bat
@@ -1,0 +1,9 @@
+@echo off
+call parameters.bat
+cd /D %toolsPath%
+@echo on
+
+python3 -m ectf_tools device.load_hw --dev-in %fobPath% --dev-name %unpairName% --dev-serial %serialPort%
+pause
+python3 -m ectf_tools device.bridge --bridge-id %unpairSocket% --dev-serial %serialPort%
+pause

--- a/scripts/Trevor/Windows/parameters.bat
+++ b/scripts/Trevor/Windows/parameters.bat
@@ -1,0 +1,29 @@
+set designPath=C:\Users\trevo\Desktop\eCTF\2023-ectf-UB-Cacti-design-main
+set toolsPath=C:\Users\trevo\Desktop\eCTF\2023-ectf-tools-main
+set hostToolPath=C:\Users\trevo\Desktop\eCTF\2023-ectf-UB-Cacti-design-main\host_tools
+
+set sysName=cacti
+set deplName=cacti-deploy
+
+set carPath=C:\Users\trevo\Desktop\eCTF\bin\car
+set carName=car
+
+set fobPath=C:\Users\trevo\Desktop\eCTF\bin\fob
+set pairName=fob
+set unpairName=unpairedFob
+
+set packagePath=C:\Users\trevo\Desktop\eCTF\bin\package
+set packageName=package
+set /A featureNum=2
+
+set /A carID=0
+set /A pairPIN=1
+
+set /A carSocket=3333
+set /A pairSocket=3334
+set /A unpairSocket=3335
+set /A enableSocket=%pairSocket%
+
+set serialPort=COM5
+set carSerial=COM6
+

--- a/scripts/Trevor/Windows/runEnable.bat
+++ b/scripts/Trevor/Windows/runEnable.bat
@@ -1,0 +1,7 @@
+@echo off
+call parameters.bat
+cd /D %toolsPath%
+@echo on
+
+python3 -m ectf_tools run.enable --name %sysName% --fob-bridge %enableSocket% --package-in %packagePath% --package-name %packageName%
+pause

--- a/scripts/Trevor/Windows/runPackage.bat
+++ b/scripts/Trevor/Windows/runPackage.bat
@@ -1,0 +1,7 @@
+@echo off
+call parameters.bat
+cd /D %toolsPath%
+@echo on
+
+python3 -m ectf_tools run.package --name %sysName% --deployment %deplName% --package-out %packagePath% --package-name %packageName% --car-id %carID% --feature-number %featureNum%
+pause

--- a/scripts/Trevor/Windows/runPair.bat
+++ b/scripts/Trevor/Windows/runPair.bat
@@ -1,0 +1,7 @@
+@echo off
+call parameters.bat
+cd /D %toolsPath%
+@echo on
+
+python3 -m ectf_tools run.pair --name %sysName% --unpaired-fob-bridge %unpairSocket% --paired-fob-bridge %pairSocket% --pair-pin %pairPIN%
+pause

--- a/scripts/Trevor/Windows/runUnlock.bat
+++ b/scripts/Trevor/Windows/runUnlock.bat
@@ -1,0 +1,8 @@
+@echo off
+call parameters.bat
+cd /D %toolsPath%
+@echo on
+
+python3 -m ectf_tools run.unlock --car-bridge %carSerial% --host-tools %hostToolPath%
+
+pause

--- a/scripts/Trevor/enable_tool.py
+++ b/scripts/Trevor/enable_tool.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python3 -u
+
+# @file enable_tool
+# @author Frederich Stine
+# @brief host tool for enabling a feature on a fob
+# @date 2023
+#
+# This source file is part of an example system for MITRE's 2023 Embedded
+# CTF (eCTF). This code is being provided only for educational purposes for the
+# 2023 MITRE eCTF competition, and may not meet MITRE standards for quality.
+# Use this code at your own risk!
+#
+# @copyright Copyright (c) 2023 The MITRE Corporation
+
+import serial
+import argparse
+
+
+# @brief Function to send commands to enable a feature on a fob
+# @param fob_bridge, bridged serial connection to fob
+# @param package_name, name of the package file to read from
+def enable(fob_bridge, package_name):
+
+    # Connect fob to serial
+    fob_connection = serial.Serial(fob_bridge, 115200, timeout=1)
+    fob_connection.reset_input_buffer()
+
+    # Send enable command to fob
+    fob_connection.write(b"enable\n")
+
+    # Open and read binary data from package file
+    with open(f"/package_dir/{package_name}", "rb") as fhandle:
+        message = fhandle.read()
+
+    # Send package to fob
+    fob_connection.write(message)
+
+    # Set timeout for if enable fails
+    fob_connection.timeout = 5
+
+    # Try to receive data - if failed, enabling failed
+    try:
+        enable_success = fob_connection.read(7)
+        while len(enable_success) != 7:
+            enable_success += fob_connection.read(7 - len(enable_success))
+
+        print(enable_success)
+    except serial.SerialTimeoutException:
+        print("Failed to enable feature")
+
+    return 0
+
+
+# @brief Main function
+#
+# Main function handles parsing arguments and passing them to program
+# function.
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--fob-bridge", help="Serial port for the fob", type=str, required=True,
+    )
+    parser.add_argument(
+        "--package-name", help="Name of the package file", type=str, required=True,
+    )
+
+    args = parser.parse_args()
+
+    enable(args.fob_bridge, args.package_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/Trevor/pair_tool.py
+++ b/scripts/Trevor/pair_tool.py
@@ -1,0 +1,82 @@
+#!/usr/bin/python3 -u
+
+# @file pair_tool
+# @author Frederich Stine
+# @brief host tool for pairing a new key fob
+# @date 2023
+#
+# This source file is part of an example system for MITRE's 2023 Embedded
+# CTF (eCTF). This code is being provided only for educational purposes for the
+# 2023 MITRE eCTF competition, and may not meet MITRE standards for quality.
+# Use this code at your own risk!
+#
+# @copyright Copyright (c) 2023 The MITRE Corporation
+
+import serial
+import argparse
+
+
+# @brief Function to send commands to pair
+# a new fob.
+# @param unpairmed_fob_bridge, bridged serial connection to unpairmed fob
+# @param pairmed_fob_bridge, bridged serial connection to pairmed fob
+# @param pair_pin, pin used to pair a new fob
+def pair(unpaired_fob_bridge, paired_fob_bridge, pair_pin):
+
+    # Connect to both serial ports
+    unpaired_connection = serial.Serial(unpaired_fob_bridge, 115200, timeout=5)
+    unpaired_connection.reset_input_buffer()
+
+    paired_connection = serial.Serial(paired_fob_bridge, 115200, timeout=5)
+    paired_connection.reset_input_buffer()
+
+    # Send pair commands to both fobs
+    unpaired_connection.write(b"pair\n")
+    paired_connection.write(b"pair\n")
+
+    # Send pin to the paired fob
+    pair_pin_bytes = str.encode(pair_pin + "\n")
+    paired_connection.write(pair_pin_bytes)
+
+    # Try to receive data - if failed, pairing failed
+    try:
+        pair_success = unpaired_connection.read(6)
+        while len(pair_success) != 6:
+            pair_success += unpaired_connection.read(6 - len(pair_success))
+
+        print(pair_success)
+    except serial.SerialTimeoutException:
+        print("Failed to pair fob")
+
+    return 0
+
+
+# @brief Main function
+#
+# Main function handles parsing arguments and passing them to pair
+# function.
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--unpaired-fob-bridge",
+        help="Serial port for the unpaired fob",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "--paired-fob-bridge",
+        help="Serial port for the paired fob",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "--pair-pin", help="Program PIN", type=str, required=True,
+    )
+
+    args = parser.parse_args()
+
+    pair(args.unpaired_fob_bridge, args.paired_fob_bridge, args.pair_pin)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/Trevor/unlock_tool.py
+++ b/scripts/Trevor/unlock_tool.py
@@ -45,7 +45,7 @@ def unlock(serial_port):
 
             # Read 1 byte from serial
             unlock_received += car_connection.read()
-        except serial.timeout:
+        except serial.SerialTimeoutException:
             print("Serial timeout - finished receiving")
             break
 

--- a/scripts/Trevor/unlock_tool.py
+++ b/scripts/Trevor/unlock_tool.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python3 -u
+
+# @file unlock_tool
+# @author Frederich Stine
+# @brief host tool for monitoring an unlock
+# @date 2023
+#
+# This source file is part of an example system for MITRE's 2023 Embedded
+# CTF (eCTF). This code is being provided only for educational purposes for the
+# 2023 MITRE eCTF competition, and may not meet MITRE standards for quality.
+# Use this code at your own risk!
+#
+# @copyright Copyright (c) 2023 The MITRE Corporation
+
+import time
+import argparse
+import serial
+
+
+# @brief Function to monitor unlocking car
+# @param car_bridge, bridged serial connection to car
+def unlock(serial_port):
+
+    # Connect to car serial
+    car_connection = serial.Serial(serial_port, 115200, timeout=1)
+    car_connection.reset_input_buffer()
+
+    # Begin time tracking
+    delta_time = 0
+    time_last = time.time()
+
+    # Try to receive data while unlocking - if empty, unlock failed
+    unlock_received: bytes = b""
+    while True:
+        try:
+            # Update delta time
+            new_time = time.time()
+            delta_time += new_time - time_last
+            time_last = new_time
+
+            if (delta_time >= 5):
+                # Exit loop after 5 seconds
+                print("finished receiving")
+                break
+
+            # Read 1 byte from serial
+            unlock_received += car_connection.read()
+        except serial.timeout:
+            print("Serial timeout - finished receiving")
+            break
+
+    # If no data receive, unlock failed
+    if len(unlock_received) == 0:
+        print("Failed to unlock")
+    # If data received, print out unlock message and features
+    else:
+        print(unlock_received)
+
+    return 0
+
+
+# @brief Main function
+#
+# Main function handles parsing arguments and passing them to unlock
+# function.
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--car-bridge", help="Serial port for the car", required=True,
+    )
+
+    args = parser.parse_args()
+
+    unlock(args.car_bridge)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/enable_tool.py
+++ b/scripts/enable_tool.py
@@ -1,0 +1,72 @@
+#!/usr/bin/python3 -u
+
+# @file enable_tool
+# @author Frederich Stine
+# @brief host tool for enabling a feature on a fob
+# @date 2023
+#
+# This source file is part of an example system for MITRE's 2023 Embedded
+# CTF (eCTF). This code is being provided only for educational purposes for the
+# 2023 MITRE eCTF competition, and may not meet MITRE standards for quality.
+# Use this code at your own risk!
+#
+# @copyright Copyright (c) 2023 The MITRE Corporation
+
+import socket
+import argparse
+
+
+# @brief Function to send commands to enable a feature on a fob
+# @param fob_bridge, bridged serial connection to fob
+# @param package_name, name of the package file to read from
+def enable(fob_bridge, package_name):
+
+    # Connect fob socket to serial
+    fob_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    fob_sock.connect(("ectf-net", int(fob_bridge)))
+
+    # Send enable command to fob
+    fob_sock.send(b"enable\n")
+
+    # Open and read binary data from package file
+    with open(f"../package/{package_name}", "rb") as fhandle:
+        message = fhandle.read()
+
+    # Send package to fob
+    fob_sock.send(message)
+
+    # Set timeout for if enable fails
+    fob_sock.settimeout(5)
+    # Try to receive data - if failed, enabling failed
+    try:
+        enable_success = fob_sock.recv(7)
+        while len(enable_success) != 7:
+            enable_success += fob_sock.recv(7 - len(enable_success))
+
+        print(enable_success)
+    except socket.timeout:
+        print("Failed to enable feature")
+
+    return 0
+
+
+# @brief Main function
+#
+# Main function handles parsing arguments and passing them to program
+# function.
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--fob-bridge", help="Bridge for the fob", type=int, required=True,
+    )
+    parser.add_argument(
+        "--package-name", help="Name of the package file", type=str, required=True,
+    )
+
+    args = parser.parse_args()
+
+    enable(args.fob_bridge, args.package_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/tasks.md
+++ b/tasks.md
@@ -1,0 +1,19 @@
+# Tasks
+
+## Attack and Design
+
+- Develop exploits for the `uart_readline()` buffer overflow. One exploit for arbitrary read. Another exploit for arbitrary write. Test the exploits on the reference system (Gaoxiang)
+- Fix the `uart_readline` bug by adding length in the function (Gaoxiang)
+- Fix `strcpy()` and other unsafe functions
+- Add stack cookies in compiling our system (Zheyuan)
+- Add MPU to add DEP to stack (Zheyuan)
+- Check the entropy source of MBed TLS (Zheyuan, Xi)
+
+## Tools
+
+1. Port the host tools to be independent from the docker conatiner
+   - unlock_tool
+   - pair_tool
+   - enable_tool
+2. Build a customized board firmware that can receive the `UART1` message, relay it, and send it out through `UART0`
+3. Build a customized board firmware and a host tool. The firmware can receive the `UART1` message, relay it to `UART0`. It also can receive message from `UART0` and send through the `UART1`. The host tool is able to receive the message from `UART0` and send it back to `UART0`


### PR DESCRIPTION
the instruction under "Using the eCTF Tools Repository" 3d has a typo:
`--package_in <PACKAGE_IN> --package_name <PACKAGE_NAME>`
Should be:
`--package-in <PACKAGE_IN> --package-name <PACKAGE_NAME>`

The docker prune command does not support "-a" flag.