### PR TITLE
Add "--rm" flag to docker run invocations in run.py

### DIFF
--- a/ectf_tools/run.py
+++ b/ectf_tools/run.py
@@ -34,6 +34,7 @@ async def unlock(
 
     ret = await run_shell(
         "docker run"
+        " --rm"
         " --add-host ectf-net:host-gateway"
         f" -v {image}.{name}.tools.vol:/tools_out:ro"
         " --workdir=/tools_out"
@@ -65,6 +66,7 @@ async def pair(
 
     ret = await run_shell(
         "docker run"
+        " --rm"
         " --add-host ectf-net:host-gateway"
         f" -v {image}.{name}.tools.vol:/tools_out:ro"
         " --workdir=/tools_out"
@@ -97,6 +99,7 @@ async def package(
 
     ret = await run_shell(
         "docker run"
+        " --rm"
         " --add-host ectf-net:host-gateway"
         f" -v {image}.{name}.{deployment}.secrets.vol:/secrets"
         f" -v {image}.{name}.tools.vol:/tools_out:ro"
@@ -131,6 +134,7 @@ async def enable(
 
     ret = await run_shell(
         "docker run"
+        " --rm"
         " --add-host ectf-net:host-gateway"
         f" -v {image}.{name}.tools.vol:/tools_out:ro"
         " --workdir=/tools_out"


### PR DESCRIPTION
There wouldn't really be a need to inspect containers created by running host tools after running said host tools, and persistent state would need to go into the writable volumes anyways in order to be reused between runs. Removing the containers after each run reduces the disk space taken up by stopped containers.

Other stopped containers may also be automatically removable, but I did not go through all of them to see if this is the case.