### PR TITLE
Fix pyserial forcing nonblocking serial device on Linux and spurious null bytes

### DIFF
--- a/ectf_tools/device.py
+++ b/ectf_tools/device.py
@@ -146,9 +146,9 @@ async def load_hw(
 
     # Try to connect to the serial port
     logger.info(f"Connecting to serial port {dev_serial}...")
-    ser = Serial(dev_serial, 115200, timeout=2, inter_byte_timeout=0)
     if platform == "linux":
-        subprocess.run(["stty", "-F", dev_serial, "ignbrk", "echo"])
+        subprocess.run(["stty", "-F", dev_serial, "brkint", "noflsh"])
+    ser = Serial(dev_serial, 115200, timeout=2, inter_byte_timeout=0)
     ser.reset_input_buffer()
     logger.info(f"Connection opened on {dev_serial}")
 
@@ -237,9 +237,9 @@ async def load_sec_hw(
 
     # Try to connect to the serial port
     logger.info(f"Connecting to serial port {dev_serial}...")
-    ser = Serial(dev_serial, 115200, timeout=2, inter_byte_timeout=0)
     if platform == "linux":
-        subprocess.run(["stty", "-F", dev_serial, "ignbrk", "echo"])
+        subprocess.run(["stty", "-F", dev_serial, "brkint", "noflsh"])
+    ser = Serial(dev_serial, 115200, timeout=2, inter_byte_timeout=0)
     ser.reset_input_buffer()
     logger.info(f"Connection opened on {dev_serial}")
 
@@ -303,12 +303,13 @@ async def mode_change(
     logger = logger or logging.getLogger()
 
     # Open serial ports
-    ser1 = Serial(dev1_serial, 115200, timeout=2, inter_byte_timeout=0)
-    ser2 = Serial(dev2_serial, 115200, timeout=2, inter_byte_timeout=0)
     if platform == "linux":
-        subprocess.run(["stty", "-F", dev1_serial, "ignbrk", "echo"])
-        subprocess.run(["stty", "-F", dev2_serial, "ignbrk", "echo"])
+        subprocess.run(["stty", "-F", dev1_serial, "brkint", "noflsh"])
+        subprocess.run(["stty", "-F", dev2_serial, "brkint", "noflsh"])
+    ser1 = Serial(dev1_serial, 115200, timeout=2, inter_byte_timeout=0)
     ser1.reset_input_buffer()
+
+    ser2 = Serial(dev2_serial, 115200, timeout=2, inter_byte_timeout=0)
     ser2.reset_input_buffer()
 
     logger.info(f"Connected to bootloaders on {dev1_serial} and {dev2_serial}")
@@ -388,9 +389,9 @@ class Port:
         # If not connected, try to connect to serial device
         if not self.ser:
             try:
-                ser = Serial(self.device_serial, baudrate=self.baudrate, timeout=0.1, inter_byte_timeout=0)
                 if platform == "linux":
-                    subprocess.run(["stty", "-F", self.device_serial, "ignbrk", "echo"])
+                    subprocess.run(["stty", "-F", self.device_serial, "brkint", "noflsh"])
+                ser = Serial(self.device_serial, baudrate=self.baudrate, timeout=0.1, inter_byte_timeout=0)
                 ser.reset_input_buffer()
                 self.ser = ser
                 self.logger.info(f"Connection opened on {self.device_serial}")

--- a/ectf_tools/device.py
+++ b/ectf_tools/device.py
@@ -10,11 +10,13 @@
 
 import asyncio
 import logging
-import socket
 import select
+import socket
+import subprocess
 from enum import Enum
 from pathlib import Path
 from rich.progress import Progress
+from sys import platform
 from typing import Optional
 
 from serial import Serial
@@ -144,6 +146,8 @@ async def load_hw(
 
     # Try to connect to the serial port
     logger.info(f"Connecting to serial port {dev_serial}...")
+    if platform != "win32":
+        subprocess.run(["stty", "-F", dev_serial, "brkint"])
     ser = Serial(dev_serial, 115200, timeout=2, inter_byte_timeout=0)
     ser.reset_input_buffer()
     logger.info(f"Connection opened on {dev_serial}")
@@ -233,6 +237,8 @@ async def load_sec_hw(
 
     # Try to connect to the serial port
     logger.info(f"Connecting to serial port {dev_serial}...")
+    if platform != "win32":
+        subprocess.run(["stty", "-F", dev_serial, "brkint"])
     ser = Serial(dev_serial, 115200, timeout=2, inter_byte_timeout=0)
     ser.reset_input_buffer()
     logger.info(f"Connection opened on {dev_serial}")
@@ -297,6 +303,9 @@ async def mode_change(
     logger = logger or logging.getLogger()
 
     # Open serial ports
+    if platform != "win32":
+        subprocess.run(["stty", "-F", dev1_serial, "brkint"])
+        subprocess.run(["stty", "-F", dev2_serial, "brkint"])
     ser1 = Serial(dev1_serial, 115200, timeout=2, inter_byte_timeout=0)
     ser1.reset_input_buffer()
 
@@ -380,6 +389,8 @@ class Port:
         # If not connected, try to connect to serial device
         if not self.ser:
             try:
+                if platform != "win32":
+                    subprocess.run(["stty", "-F", self.device_serial, "brkint"])
                 ser = Serial(self.device_serial, baudrate=self.baudrate, timeout=0.1, inter_byte_timeout=0)
                 ser.reset_input_buffer()
                 self.ser = ser

--- a/ectf_tools/device.py
+++ b/ectf_tools/device.py
@@ -146,9 +146,9 @@ async def load_hw(
 
     # Try to connect to the serial port
     logger.info(f"Connecting to serial port {dev_serial}...")
-    if platform == "linux":
-        subprocess.run(["stty", "-F", dev_serial, "brkint"])
     ser = Serial(dev_serial, 115200, timeout=2, inter_byte_timeout=0)
+    if platform == "linux":
+        subprocess.run(["stty", "-F", dev_serial, "ignbrk", "echo"])
     ser.reset_input_buffer()
     logger.info(f"Connection opened on {dev_serial}")
 
@@ -237,9 +237,9 @@ async def load_sec_hw(
 
     # Try to connect to the serial port
     logger.info(f"Connecting to serial port {dev_serial}...")
-    if platform == "linux":
-        subprocess.run(["stty", "-F", dev_serial, "brkint"])
     ser = Serial(dev_serial, 115200, timeout=2, inter_byte_timeout=0)
+    if platform == "linux":
+        subprocess.run(["stty", "-F", dev_serial, "ignbrk", "echo"])
     ser.reset_input_buffer()
     logger.info(f"Connection opened on {dev_serial}")
 
@@ -303,13 +303,12 @@ async def mode_change(
     logger = logger or logging.getLogger()
 
     # Open serial ports
-    if platform == "linux":
-        subprocess.run(["stty", "-F", dev1_serial, "brkint"])
-        subprocess.run(["stty", "-F", dev2_serial, "brkint"])
     ser1 = Serial(dev1_serial, 115200, timeout=2, inter_byte_timeout=0)
-    ser1.reset_input_buffer()
-
     ser2 = Serial(dev2_serial, 115200, timeout=2, inter_byte_timeout=0)
+    if platform == "linux":
+        subprocess.run(["stty", "-F", dev1_serial, "ignbrk", "echo"])
+        subprocess.run(["stty", "-F", dev2_serial, "ignbrk", "echo"])
+    ser1.reset_input_buffer()
     ser2.reset_input_buffer()
 
     logger.info(f"Connected to bootloaders on {dev1_serial} and {dev2_serial}")
@@ -389,9 +388,9 @@ class Port:
         # If not connected, try to connect to serial device
         if not self.ser:
             try:
-                if platform == "linux":
-                    subprocess.run(["stty", "-F", self.device_serial, "brkint"])
                 ser = Serial(self.device_serial, baudrate=self.baudrate, timeout=0.1, inter_byte_timeout=0)
+                if platform == "linux":
+                    subprocess.run(["stty", "-F", self.device_serial, "ignbrk", "echo"])
                 ser.reset_input_buffer()
                 self.ser = ser
                 self.logger.info(f"Connection opened on {self.device_serial}")

--- a/ectf_tools/device.py
+++ b/ectf_tools/device.py
@@ -144,7 +144,7 @@ async def load_hw(
 
     # Try to connect to the serial port
     logger.info(f"Connecting to serial port {dev_serial}...")
-    ser = Serial(dev_serial, 115200, timeout=2)
+    ser = Serial(dev_serial, 115200, timeout=2, inter_byte_timeout=0)
     ser.reset_input_buffer()
     logger.info(f"Connection opened on {dev_serial}")
 
@@ -233,7 +233,7 @@ async def load_sec_hw(
 
     # Try to connect to the serial port
     logger.info(f"Connecting to serial port {dev_serial}...")
-    ser = Serial(dev_serial, 115200, timeout=2)
+    ser = Serial(dev_serial, 115200, timeout=2, inter_byte_timeout=0)
     ser.reset_input_buffer()
     logger.info(f"Connection opened on {dev_serial}")
 
@@ -297,10 +297,10 @@ async def mode_change(
     logger = logger or logging.getLogger()
 
     # Open serial ports
-    ser1 = Serial(dev1_serial, 115200, timeout=2)
+    ser1 = Serial(dev1_serial, 115200, timeout=2, inter_byte_timeout=0)
     ser1.reset_input_buffer()
 
-    ser2 = Serial(dev2_serial, 115200, timeout=2)
+    ser2 = Serial(dev2_serial, 115200, timeout=2, inter_byte_timeout=0)
     ser2.reset_input_buffer()
 
     logger.info(f"Connected to bootloaders on {dev1_serial} and {dev2_serial}")
@@ -380,7 +380,7 @@ class Port:
         # If not connected, try to connect to serial device
         if not self.ser:
             try:
-                ser = Serial(self.device_serial, baudrate=self.baudrate, timeout=0.1)
+                ser = Serial(self.device_serial, baudrate=self.baudrate, timeout=0.1, inter_byte_timeout=0)
                 ser.reset_input_buffer()
                 self.ser = ser
                 self.logger.info(f"Connection opened on {self.device_serial}")

--- a/ectf_tools/device.py
+++ b/ectf_tools/device.py
@@ -146,7 +146,7 @@ async def load_hw(
 
     # Try to connect to the serial port
     logger.info(f"Connecting to serial port {dev_serial}...")
-    if platform != "win32":
+    if platform == "linux":
         subprocess.run(["stty", "-F", dev_serial, "brkint"])
     ser = Serial(dev_serial, 115200, timeout=2, inter_byte_timeout=0)
     ser.reset_input_buffer()
@@ -237,7 +237,7 @@ async def load_sec_hw(
 
     # Try to connect to the serial port
     logger.info(f"Connecting to serial port {dev_serial}...")
-    if platform != "win32":
+    if platform == "linux":
         subprocess.run(["stty", "-F", dev_serial, "brkint"])
     ser = Serial(dev_serial, 115200, timeout=2, inter_byte_timeout=0)
     ser.reset_input_buffer()
@@ -303,7 +303,7 @@ async def mode_change(
     logger = logger or logging.getLogger()
 
     # Open serial ports
-    if platform != "win32":
+    if platform == "linux":
         subprocess.run(["stty", "-F", dev1_serial, "brkint"])
         subprocess.run(["stty", "-F", dev2_serial, "brkint"])
     ser1 = Serial(dev1_serial, 115200, timeout=2, inter_byte_timeout=0)
@@ -389,7 +389,7 @@ class Port:
         # If not connected, try to connect to serial device
         if not self.ser:
             try:
-                if platform != "win32":
+                if platform == "linux":
                     subprocess.run(["stty", "-F", self.device_serial, "brkint"])
                 ser = Serial(self.device_serial, baudrate=self.baudrate, timeout=0.1, inter_byte_timeout=0)
                 ser.reset_input_buffer()


### PR DESCRIPTION
On Linux, pyserial forces `vmin` to 0 if `inter_byte_timeout` is `None`, which is the default behavior.
When `vmin` is 0, reads to the device can return a minimum of 0 bytes, in other words they return immediately if no data is buffered.
This breaks tools that assume reading from the serial device will block until data is found.
See [this](https://github.com/mitre-cyber-academy/2023-ectf-tools/pull/6#issuecomment-1449790759) thread for more details.

In some cases, spurious null bytes are emitted due to break conditions being interpreted as nulls.
This is fixed by enabling `BRKINT` and `NOFLSH`, which will prevent break conditions from being interpreted as null bytes.